### PR TITLE
Fix password reset functionality when OAuth is enabled

### DIFF
--- a/src/AuthManagerOAuthPrimaryAuthenticationProvider.php
+++ b/src/AuthManagerOAuthPrimaryAuthenticationProvider.php
@@ -109,7 +109,11 @@ class AuthManagerOAuthPrimaryAuthenticationProvider extends \MediaWiki\Auth\Abst
 				__METHOD__,
 			);
 		} else {
-			throw new LogicException( "Unexpected unhandled request" );
+			// If this is not an OAuth-related request (e.g., password change),
+			// we should ignore it since OAuth providers don't handle local passwords
+			// Just return without doing anything
+			wfDebugLog( 'AuthManagerOAuth', 'Ignoring non-OAuth request in providerChangeAuthenticationData' );
+			return;
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR fixes issue #40 where the MediaWiki password reset functionality (via maintenance scripts) fails with a LogicException when OAuth authentication is enabled.

## Problem

When administrators try to reset user passwords using MediaWiki's  maintenance script, the  method in  throws a LogicException for any non-OAuth authentication request. This prevents password resets from working.

## Solution

This patch modifies the provider to silently ignore non-OAuth authentication data changes (like password resets) instead of throwing an exception. OAuth providers don't handle local passwords, so they should simply return without action when encountering such requests.

## Testing

- The fix has been tested in production on the NixOS Wiki
- Password resets via maintenance scripts now work correctly
- OAuth login functionality remains unaffected

Fixes #40