### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Enable version updates for Composer
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "composer"
+      include: "scope"
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "dependencies"
+      - "php"
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
## Summary
- Add Dependabot configuration to automate dependency updates for GitHub Actions and Composer packages

## Details
This PR adds a `.github/dependabot.yml` configuration file that enables Dependabot to:
- Check for GitHub Actions updates weekly
- Check for Composer dependency updates weekly
- Create pull requests with semantic commit prefixes and appropriate labels

This helps maintain the security and freshness of dependencies by automatically creating PRs when new versions are available.