### PR TITLE
Update GitHub Actions to v4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,12 +13,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -32,10 +32,10 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: composer install --no-dev
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: AuthManagerOAuth
         retention-days: 3


### PR DESCRIPTION
## Summary
- Update all GitHub Actions from v3 to v4

## Changes
- `actions/checkout@v3` → `actions/checkout@v4`
- `actions/cache@v3` → `actions/cache@v4`
- `actions/upload-artifact@v3` → `actions/upload-artifact@v4`

## Benefits
- Security updates and bug fixes
- Performance improvements
- Continued support (v3 actions are deprecated)
- Node.js 20 runtime (v3 uses the older Node.js 16)

All v4 actions maintain backward compatibility with v3.